### PR TITLE
Solver.minimize() don't skip rows

### DIFF
--- a/flip.py
+++ b/flip.py
@@ -247,17 +247,16 @@ class Solver:
    def minimize(self):
       # Temporary variable to work on toggles
       work = self.toggles
+      keep = [];
 
       # If i is in the list an even number of times, remove it,
       # else, keep it
       for i in work:
-         work.remove(i)
-         if i in work:
-            work.remove(i)
-         else:
+         if work.count(i) % 2 == 1:
+            keep.append(i)
             work.append(i)
 
-      self.toggles = work
+      self.toggles = keep
       self.moves = len(work)
 
    # Returns true if every light is set to zero

--- a/flip.py
+++ b/flip.py
@@ -63,6 +63,11 @@ class Grid:
          for x, j in enumerate(i):
             self.grid[y][x] = 0
 
+   def fill(self):
+      for y, i in enumerate(self.grid):
+         for x, j in enumerate(i):
+            self.grid[y][x] = 1
+
    # Returns 0 or 1 depending on the light's state
    def get(self, x, y):
       if x > self.width - 1 or y > self.height - 1:


### PR DESCRIPTION
The current version of Solver.minimize() skips odd rows.
So write a new one.